### PR TITLE
fix: align agent register defaults with setup behavior

### DIFF
--- a/src/cli/commands/setup/config-file.ts
+++ b/src/cli/commands/setup/config-file.ts
@@ -10,7 +10,7 @@ import {
   DEFAULT_SETUP_PERMISSION_LEVEL,
   DEFAULT_SETUP_PROVIDER,
   DEFAULT_SETUP_REASONING_EFFORT,
-  getDefaultSetupAgentDescription,
+  getDefaultAgentDescription,
   getDefaultSetupBossName,
   getDefaultSetupWorkspace,
 } from "../../../shared/defaults.js";
@@ -133,7 +133,7 @@ function parseSetupConfigFileV1(json: string): SetupConfig {
   const agentDescription =
     typeof agentDescriptionRaw === "string"
       ? agentDescriptionRaw
-      : getDefaultSetupAgentDescription(agentName);
+      : getDefaultAgentDescription(agentName);
 
   const workspaceRaw = agentRaw.workspace;
   const workspace =

--- a/src/cli/commands/setup/interactive.ts
+++ b/src/cli/commands/setup/interactive.ts
@@ -10,7 +10,7 @@ import {
   DEFAULT_SETUP_MODEL_BY_PROVIDER,
   DEFAULT_SETUP_REASONING_EFFORT,
   SETUP_MODEL_CHOICES_BY_PROVIDER,
-  getDefaultSetupAgentDescription,
+  getDefaultAgentDescription,
   getDefaultSetupBossName,
   getDefaultSetupWorkspace,
 } from "../../../shared/defaults.js";
@@ -128,7 +128,7 @@ export async function runInteractiveSetup(): Promise<void> {
     })
   ).trim();
 
-  const defaultAgentDescription = getDefaultSetupAgentDescription(agentName);
+  const defaultAgentDescription = getDefaultAgentDescription(agentName);
   const agentDescriptionInput = await input({
     message: `Agent description: (Default: ${defaultAgentDescription})`,
   });

--- a/src/daemon/db/database.ts
+++ b/src/daemon/db/database.ts
@@ -10,7 +10,7 @@ import {
   DEFAULT_AGENT_AUTO_LEVEL,
   DEFAULT_AGENT_PERMISSION_LEVEL,
   DEFAULT_AGENT_PROVIDER,
-  DEFAULT_AGENT_REASONING_EFFORT,
+  getDefaultAgentDescription,
 } from "../../shared/defaults.js";
 import { generateToken, hashToken, verifyToken } from "../../agent/auth.js";
 import { generateUUID } from "../../shared/uuid.js";
@@ -290,9 +290,6 @@ export class HiBossDatabase {
     const token = generateToken();
     const createdAt = Date.now();
 
-    const reasoningEffortToStore =
-      input.reasoningEffort === undefined ? DEFAULT_AGENT_REASONING_EFFORT : input.reasoningEffort;
-
     const stmt = this.db.prepare(`
       INSERT INTO agents (name, token, description, workspace, provider, model, reasoning_effort, auto_level, permission_level, session_policy, created_at, metadata)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -301,11 +298,11 @@ export class HiBossDatabase {
     stmt.run(
       input.name,
       token,  // store raw token directly
-      input.description ?? null,
+      input.description ?? getDefaultAgentDescription(input.name),
       input.workspace ?? null,
       input.provider ?? DEFAULT_AGENT_PROVIDER,
       input.model ?? null,
-      reasoningEffortToStore,
+      input.reasoningEffort ?? null,
       input.autoLevel ?? DEFAULT_AGENT_AUTO_LEVEL,
       input.permissionLevel ?? DEFAULT_AGENT_PERMISSION_LEVEL,
       input.sessionPolicy ? JSON.stringify(input.sessionPolicy) : null,

--- a/src/daemon/db/schema.ts
+++ b/src/daemon/db/schema.ts
@@ -6,7 +6,6 @@ import {
   DEFAULT_AGENT_AUTO_LEVEL,
   DEFAULT_AGENT_PERMISSION_LEVEL,
   DEFAULT_AGENT_PROVIDER,
-  DEFAULT_AGENT_REASONING_EFFORT,
   DEFAULT_AGENT_RUN_STATUS,
   DEFAULT_ENVELOPE_STATUS,
 } from "../../shared/defaults.js";
@@ -25,7 +24,7 @@ CREATE TABLE IF NOT EXISTS config (
 	  workspace TEXT,
 	  provider TEXT DEFAULT '${DEFAULT_AGENT_PROVIDER}',
   model TEXT,
-  reasoning_effort TEXT DEFAULT '${DEFAULT_AGENT_REASONING_EFFORT}',
+  reasoning_effort TEXT,
   auto_level TEXT DEFAULT '${DEFAULT_AGENT_AUTO_LEVEL}',
   permission_level TEXT DEFAULT '${DEFAULT_AGENT_PERMISSION_LEVEL}',
   session_policy TEXT,           -- JSON blob for SessionPolicyConfig

--- a/src/shared/defaults.ts
+++ b/src/shared/defaults.ts
@@ -70,7 +70,7 @@ export const SETUP_MODEL_CHOICES_BY_PROVIDER = {
   codex: ["gpt-5.2", "gpt-5.2-codex"],
 } as const;
 
-export function getDefaultSetupAgentDescription(agentName: string): string {
+export function getDefaultAgentDescription(agentName: string): string {
   void agentName; // reserved for future personalization
   return "A reliable and collaborative professional who delivers results with clarity and respect for others, and consistently makes teamwork more effective and enjoyable.";
 }


### PR DESCRIPTION
## Summary
- **reasoning-effort**: default to `null` instead of hardcoding `"medium"`, letting the provider SDK use its own default (consistent with how `model` is handled)
- **description**: default to the standard agent description when not specified, matching the setup flow behavior
- Rename `getDefaultSetupAgentDescription` → `getDefaultAgentDescription` (now shared between setup and register)
- Remove `reasoning_effort` column DEFAULT from schema for consistency

## Test plan
- [ ] Register a new agent without `--description` → should get default description
- [ ] Register a new agent without `--reasoning-effort` → DB stores null, `agent status` shows "default"
- [ ] Existing agents unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)