### PR TITLE
Terminalize undeliverable envelopes (no retry)

### DIFF
--- a/docs/spec/cli/envelopes.md
+++ b/docs/spec/cli/envelopes.md
@@ -22,6 +22,7 @@ Flags:
 Notes:
 - Sender identity is derived from the authenticated **agent token**.
 - Boss tokens cannot send envelopes via `hiboss envelope send`; to message an agent as a human/boss, send via a channel adapter (e.g., Telegram).
+- Sending to `agent:<name>` fails fast if the agent does not exist (`NOT_FOUND`) or the address is invalid (`INVALID_PARAMS`).
 
 Output (parseable):
 

--- a/docs/spec/components/scheduler.md
+++ b/docs/spec/components/scheduler.md
@@ -48,9 +48,11 @@ Each tick does:
 1. **Deliver due channel envelopes**
    - `db.listDueChannelEnvelopes(limit)` returns due envelopes where `to LIKE 'channel:%'`
    - The scheduler calls `router.deliverEnvelope(env)` for each
+   - If a channel delivery fails, the envelope is marked `done` (terminal) and `last-delivery-error-*` is recorded (no auto-retry)
 2. **Trigger agents with due envelopes**
    - `db.listAgentNamesWithDueEnvelopes()` returns agent names with due pending envelopes
    - The scheduler calls `executor.checkAndRun(agent, db)` (non-blocking)
+   - If an envelope is addressed to a missing/deleted agent (`to = agent:<name>` with no corresponding agent record), the scheduler marks those due pending envelopes `done` (terminal) and records `last-delivery-error-*` to prevent infinite pending loops
 
 The scheduler then computes the next wake time.
 

--- a/docs/spec/definitions.md
+++ b/docs/spec/definitions.md
@@ -55,6 +55,10 @@ Table: `envelopes` (see `src/daemon/db/schema.ts`)
 | `envelope.createdAt` | `created_at` | Unix epoch ms (UTC) |
 | `envelope.metadata` | `metadata` | JSON (nullable); used for channel semantics |
 
+Status semantics:
+- `pending` means “not yet fully processed”: either waiting for `deliver-at`, waiting for agent read, or waiting for channel delivery attempt.
+- `done` means “terminal”: the envelope will not be processed again. `done` can represent a successful delivery/read, or a terminal delivery failure (with details recorded via `last-delivery-error-*` when available).
+
 ### CLI
 
 Command flags:
@@ -79,7 +83,7 @@ Command flags:
 - `in-reply-to-text:` (multiline)
   - Note: adapters may truncate `in-reply-to-text` for safety/size. The Telegram adapter truncates at 1200 characters and appends `\n\n[...truncated...]\n`.
 
-**Delivery error keys** (only when a channel delivery attempt failed)
+**Delivery error keys** (only when a delivery attempt failed or the daemon terminalized an undeliverable envelope)
 - `last-delivery-error-at:` (boss timezone offset)
 - `last-delivery-error-kind:`
 - `last-delivery-error-message:`


### PR DESCRIPTION
Fixes envelopes getting stuck in pending and re-delivered on daemon restarts.

Key changes:
- Strict address validation for agent/channel addresses.
- Fail fast when sending to missing agents (NOT_FOUND).
- Channel delivery failures are terminalized: status=done + last-delivery-error-*.
- Scheduler cleans due pending envelopes addressed to missing/deleted agents.
- Specs/docs updated (docs/spec is canonical).