### PR TITLE
Clarify setup/register defaults and require explicit provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Manage agents via the CLI (create / update / remove), and optionally delegate ad
 Create/register a new agent:
 
 ```bash
-hiboss agent register --token <boss-token> --name nex --description "AI assistant" --workspace "$PWD"
+hiboss agent register --token <boss-token> --name nex --provider codex --description "AI assistant" --workspace "$PWD"
 ```
 
 Update an agent (manual configuration):

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -17,7 +17,7 @@ Setup prints `boss-token:` and `agent-token:` once. Save them somewhere safe.
 If setup already created one agent for you, you can skip this.
 
 ```bash
-hiboss agent register --token <boss-token> --name nex --description "AI assistant" --workspace "$PWD"
+hiboss agent register --token <boss-token> --name nex --provider codex --description "AI assistant" --workspace "$PWD"
 ```
 
 This prints `token: ...` once. Save it.

--- a/docs/spec/cli/agents.md
+++ b/docs/spec/cli/agents.md
@@ -14,7 +14,7 @@ Flags:
 - `--token <token>` (optional; defaults to `HIBOSS_TOKEN`)
 - `--description <description>` (optional)
 - `--workspace <path>` (optional)
-- `--provider <claude|codex>` (optional)
+- `--provider <claude|codex>` (required)
 - `--provider-source-home <path>` (optional; when used with `--provider`, imports provider config from this directory)
 - `--model <model>` (optional)
 - `--reasoning-effort <default|none|low|medium|high|xhigh>` (optional; use `default` to clear and use provider default)
@@ -29,11 +29,27 @@ Flags:
   - `--session-idle-timeout <duration>` (units: `d/h/m/s`)
   - `--session-max-context-length <n>`
 
+Defaults (when flags are omitted):
+- `provider`: none (required)
+- `model`: provider default (`NULL` override)
+- `reasoning-effort`: provider default (`NULL` override)
+- `auto-level`: `medium`
+- `permission-level`: `standard`
+- `description`: generated default description
+- `workspace`: unset (`NULL`)
+- `session-policy`: unset
+- `metadata`: unset
+
+Notes:
+- `--model default` on register clears the model override to provider default (`NULL`).
+- `--reasoning-effort default` on register clears the reasoning-effort override to provider default (`NULL`).
+
 Provider config import:
-- When `--provider` is provided, Hi-Boss imports provider config files into the agent’s provider home.
+- Hi-Boss imports provider config files into the agent’s provider home for the effective provider.
 - If `--provider-source-home` is omitted, Hi-Boss uses the provider default source home:
   - `codex` → `~/.codex/`
   - `claude` → `~/.claude/`
+- `--provider-source-home` requires `--provider`.
 
 Output (parseable):
 - `name:`
@@ -72,6 +88,7 @@ Notes:
 - Updating `--provider`, `--model`, or `--reasoning-effort` does **not** force a session refresh. Existing/resumed sessions may continue using the previous session config until a refresh (`/new`) or policy refresh opens a new session.
 - When switching providers without specifying `--model` / `--reasoning-effort`, Hi-Boss clears these overrides so the new provider can use its defaults when a fresh session is eventually opened.
 - `--clear-metadata` clears user metadata but preserves the internal session resume handle (`metadata.sessionHandle`). The `sessionHandle` key is reserved and is ignored if provided via `--metadata-*`.
+- `--provider-source-home` requires `--provider`.
 
 Provider config import:
 - When `--provider` is provided, Hi-Boss imports provider config files into the agent’s provider home.

--- a/docs/spec/cli/setup.md
+++ b/docs/spec/cli/setup.md
@@ -15,11 +15,27 @@ Behavior:
 - Creates the agent home directories under `~/hiboss/agents/<agent-name>/`
 - Creates an empty `~/hiboss/BOSS.md` placeholder (best-effort; not rendered in minimal system prompt)
 - Creates an empty `~/hiboss/agents/<agent-name>/SOUL.md` placeholder (best-effort)
-- Imports provider config files for the chosen provider into the agent’s provider home
+- Imports provider config files for the chosen provider into the agent’s provider home (`~/.claude` for Claude, `~/.codex` for Codex, unless overridden)
 - Creates the first agent and prints `agent-token:` once (no “show token” command)
 - Prints `boss-token:` once
 - Prompts for `boss-timezone` (IANA) used for all displayed timestamps; defaults to the daemon host timezone
 - Configures and binds a Telegram adapter for the first agent
+
+Interactive defaults (when you press Enter):
+- `provider`: no default; required input (`claude` or `codex`)
+- `provider-source-home`: provider-specific default (`~/.claude` or `~/.codex`)
+- `boss-name`: current OS username
+- `boss-timezone`: daemon host timezone (IANA)
+- `agent.name`: `nex`
+- `agent.description`: generated default description
+- `agent.workspace`: user home directory
+- `agent.model`: `null` (use provider default)
+- `agent.reasoning-effort`: `null` (use provider default)
+- `agent.auto-level`: `medium`
+- `agent.permission-level`: `standard`
+- `session-policy`: unset
+- `metadata`: unset
+- `memory.mode`: `default` (download default embedding model)
 
 ## `hiboss setup --config-file <path>`
 
@@ -33,6 +49,7 @@ Usage:
 Config file must include:
 - `version: 1`
 - `boss-token: <token>`
+- `provider: <claude|codex>`
 - `boss-timezone: <iana>` (optional; defaults to daemon host timezone)
 - `agent: { ... }`
 - `telegram: { adapter-token, adapter-boss-id }`
@@ -42,6 +59,19 @@ Optional:
   - `mode`: `default` (download the default embedding model) or `local` (use a local GGUF)
   - `model-path`: required when `mode: local` (absolute path to a `.gguf`)
 - `provider-source-home: <path>` (optional; imports provider config from this directory; defaults to `~/.codex/` or `~/.claude/` based on `provider`)
+
+Config-file defaults (when omitted):
+- `provider-source-home`: provider-specific default (`~/.claude` or `~/.codex`)
+- `boss-name`: current OS username
+- `boss-timezone`: daemon host timezone (IANA)
+- `agent.name`: `nex`
+- `agent.description`: generated default description
+- `agent.workspace`: user home directory
+- `agent.model`: `null` (use provider default)
+- `agent.reasoning-effort`: `null` (use provider default)
+- `agent.auto-level`: `medium`
+- `agent.permission-level`: `standard`
+- `memory.mode`: `default`
 
 Example (`setup.json`):
 
@@ -63,8 +93,8 @@ Example (`setup.json`):
     "workspace": "/absolute/path/to/workspace",
     "model": null,
     "reasoning-effort": null,
-    "auto-level": "high",
-    "permission-level": "privileged"
+    "auto-level": "medium",
+    "permission-level": "standard"
   },
   "telegram": {
     "adapter-token": "123456789:ABCdef...",
@@ -77,6 +107,9 @@ Notes:
 - `agent.model: null` means “use the provider default model”.
 - `agent.reasoning-effort: null` means “use the provider default reasoning effort”.
 - For parity with `hiboss agent set`, the string `"default"` is also accepted for both fields (treated as `null`).
+- Setup model choices are provider-specific plus `null` plus custom input:
+  - `codex`: `null`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.3-codex`, custom model id
+  - `claude`: `null`, `haiku`, `sonnet`, `opus`, custom model id
 
 Output:
 - Setup prints tokens once, plus a small block of stable key/value lines (keys are kebab-case and may be indented in the human UI).

--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -117,7 +117,7 @@ Keys:
 - `boss_name`: boss display name used in instructions/templates
 - `boss_timezone`: boss timezone (IANA) used for all displayed timestamps
 - `boss_token_hash`: hashed admin token (not currently surfaced via CLI commands beyond setup)
-- `default_provider`: `"claude"` or `"codex"` (used by setup as a default)
+- `default_provider`: `"claude"` or `"codex"` (written by setup; informational today and not used as an implicit default by `hiboss agent register`)
 - `permission_policy`: JSON permission policy mapping operations → required permission level
 - `adapter_boss_id_<adapter-type>`: boss identity on an adapter, e.g.:
   - `adapter_boss_id_telegram = "your_username"`
@@ -140,7 +140,7 @@ Per-agent settings:
 | `provider` | TEXT | `'claude'` | `"claude"` or `"codex"` |
 | `model` | TEXT | `NULL` | Optional model name. `NULL` means “use the provider default model”. |
 | `reasoning_effort` | TEXT | `'medium'` | `"none"`, `"low"`, `"medium"`, `"high"`, or `"xhigh"`. `NULL` means “use the provider default reasoning effort”. |
-| `auto_level` | TEXT | `'high'` | `"medium"` or `"high"`. Note: unified-agent-sdk also supports `"low"`, but Hi-Boss disallows it because it can prevent the agent from running `hiboss` commands. |
+| `auto_level` | TEXT | `'medium'` | `"medium"` or `"high"`. Note: unified-agent-sdk also supports `"low"`, but Hi-Boss disallows it because it can prevent the agent from running `hiboss` commands. |
 | `permission_level` | TEXT | `'standard'` | `"restricted"`, `"standard"`, `"privileged"`, or `"boss"` |
 | `session_policy` | TEXT | `NULL` | JSON blob for SessionPolicyConfig |
 | `created_at` | INTEGER | `CAST(strftime('%s','now') AS INTEGER) * 1000` | Unix epoch ms (UTC) |

--- a/docs/spec/definitions.md
+++ b/docs/spec/definitions.md
@@ -196,11 +196,20 @@ Command flags:
 
 Provider config import:
 - `--provider-source-home <path>` overrides the source directory used to import provider config files into the agent’s provider home.
+- `--provider-source-home` requires an explicit `--provider` on `hiboss agent register` / `hiboss agent set`.
+
+Agent defaults:
+- `hiboss agent register` requires `--provider` (`claude` or `codex`).
+- `agent.model` and `agent.reasoningEffort` are nullable overrides; `NULL` means provider defaults.
+- `agent.autoLevel` defaults to `medium` when not specified.
+- `agent.permissionLevel` defaults to `standard` when not specified.
+- On `hiboss agent set`, switching provider without passing `--model` / `--reasoning-effort` clears both overrides to `NULL`.
 
 Clearing nullable overrides:
 - `hiboss agent set --model default` sets `agent.model = NULL` (provider default model)
 - `hiboss agent set --reasoning-effort default` sets `agent.reasoningEffort = NULL` (provider default reasoning effort)
 - `hiboss agent register --reasoning-effort default` sets `agent.reasoningEffort = NULL` (provider default reasoning effort)
+- `hiboss agent register --model default` sets `agent.model = NULL` (provider default model)
 
 ### CLI Output Keys
 

--- a/src/cli/cli-agent.ts
+++ b/src/cli/cli-agent.ts
@@ -18,10 +18,10 @@ export function registerAgentCommands(program: Command): void {
     .command("register")
     .description("Register a new agent")
     .requiredOption("--name <name>", "Agent name (alphanumeric with hyphens)")
+    .requiredOption("--provider <provider>", "Provider (claude or codex)")
     .option("--token <token>", "Token (defaults to HIBOSS_TOKEN)")
     .option("--description <description>", "Agent description")
     .option("--workspace <path>", "Workspace path for unified-agent-sdk")
-    .option("--provider <provider>", "Provider (claude or codex)")
     .option(
       "--provider-source-home <path>",
       "Provider source home to import config from (default: ~/.codex or ~/.claude)"

--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -45,7 +45,7 @@ export interface RegisterAgentOptions {
   name: string;
   description?: string;
   workspace?: string;
-  provider?: string;
+  provider: string;
   providerSourceHome?: string;
   model?: string;
   reasoningEffort?: string;
@@ -113,6 +113,7 @@ export async function registerAgent(options: RegisterAgentOptions): Promise<void
     }
 
     const token = resolveToken(options.token);
+    const model = normalizeDefaultSentinel(options.model);
     const reasoningEffort = normalizeDefaultSentinel(options.reasoningEffort);
     const result = await client.call<RegisterAgentResult>("agent.register", {
       token,
@@ -121,7 +122,7 @@ export async function registerAgent(options: RegisterAgentOptions): Promise<void
       workspace: options.workspace,
       provider: options.provider,
       providerSourceHome: options.providerSourceHome,
-      model: options.model,
+      model,
       reasoningEffort,
       autoLevel: options.autoLevel,
       permissionLevel: options.permissionLevel,

--- a/src/cli/commands/setup/types.ts
+++ b/src/cli/commands/setup/types.ts
@@ -15,7 +15,7 @@ export interface SetupConfig {
     model: string | null;
     reasoningEffort: "none" | "low" | "medium" | "high" | "xhigh" | null;
     autoLevel: "medium" | "high";
-    permissionLevel?: "restricted" | "standard" | "privileged";
+    permissionLevel?: "restricted" | "standard" | "privileged" | "boss";
     sessionPolicy?: {
       dailyResetAt?: string;
       idleTimeout?: string;

--- a/src/daemon/ipc/types.ts
+++ b/src/daemon/ipc/types.ts
@@ -109,7 +109,7 @@ export interface AgentRegisterParams {
   name: string;
   description?: string;
   workspace?: string;
-  provider?: "claude" | "codex";
+  provider: "claude" | "codex";
   providerSourceHome?: string;
   model?: string;
   reasoningEffort?: "none" | "low" | "medium" | "high" | "xhigh" | null;

--- a/src/daemon/rpc/agent-register-handler.ts
+++ b/src/daemon/rpc/agent-register-handler.ts
@@ -6,7 +6,6 @@ import type { Agent } from "../../agent/types.js";
 import { isValidAgentName, AGENT_NAME_ERROR_MESSAGE } from "../../shared/validation.js";
 import { parseDailyResetAt, parseDurationToMs } from "../../shared/session-policy.js";
 import { setupAgentHome } from "../../agent/home-setup.js";
-import { DEFAULT_AGENT_PROVIDER } from "../../shared/defaults.js";
 import { isPermissionLevel } from "../../shared/permissions.js";
 import { errorMessage, logEvent } from "../../shared/daemon-log.js";
 
@@ -31,13 +30,10 @@ export function createAgentRegisterHandler(ctx: DaemonContext): RpcMethodHandler
         rpcError(RPC_ERRORS.ALREADY_EXISTS, "Agent already exists");
       }
 
-      let provider: "claude" | "codex" | undefined;
-      if (p.provider !== undefined) {
-        if (p.provider !== "claude" && p.provider !== "codex") {
-          rpcError(RPC_ERRORS.INVALID_PARAMS, "Invalid provider (expected claude or codex)");
-        }
-        provider = p.provider;
+      if (p.provider !== "claude" && p.provider !== "codex") {
+        rpcError(RPC_ERRORS.INVALID_PARAMS, "Invalid provider (expected claude or codex)");
       }
+      const provider: "claude" | "codex" = p.provider;
 
       let reasoningEffort: Agent["reasoningEffort"] | null | undefined;
       if (p.reasoningEffort !== undefined) {
@@ -140,10 +136,9 @@ export function createAgentRegisterHandler(ctx: DaemonContext): RpcMethodHandler
         providerSourceHome = p.providerSourceHome.trim();
       }
 
-      const effectiveProvider = provider ?? DEFAULT_AGENT_PROVIDER;
       try {
         await setupAgentHome(p.name, ctx.config.dataDir, {
-          provider: effectiveProvider,
+          provider,
           providerSourceHome,
         });
       } catch (err) {
@@ -244,4 +239,3 @@ export function createAgentRegisterHandler(ctx: DaemonContext): RpcMethodHandler
     }
   };
 }
-

--- a/src/shared/defaults.ts
+++ b/src/shared/defaults.ts
@@ -42,7 +42,7 @@ export const DEFAULT_MEMORY_MODEL_URL =
 
 export const DEFAULT_AGENT_PROVIDER = "claude" as const;
 export const DEFAULT_AGENT_REASONING_EFFORT = "medium" as const;
-export const DEFAULT_AGENT_AUTO_LEVEL = "high" as const;
+export const DEFAULT_AGENT_AUTO_LEVEL = "medium" as const;
 export const DEFAULT_AGENT_PERMISSION_LEVEL = "standard" as const;
 
 // ==================== DB/Envelope Defaults ====================
@@ -53,21 +53,14 @@ export const DEFAULT_ENVELOPE_LIST_BOX = "inbox" as const;
 
 // ==================== Setup Defaults ====================
 
-export const DEFAULT_SETUP_PROVIDER = DEFAULT_AGENT_PROVIDER;
 export const DEFAULT_SETUP_AGENT_NAME = "nex" as const;
-export const DEFAULT_SETUP_REASONING_EFFORT = DEFAULT_AGENT_REASONING_EFFORT;
 export const DEFAULT_SETUP_AUTO_LEVEL = DEFAULT_AGENT_AUTO_LEVEL;
-export const DEFAULT_SETUP_PERMISSION_LEVEL = "privileged" as const;
+export const DEFAULT_SETUP_PERMISSION_LEVEL = DEFAULT_AGENT_PERMISSION_LEVEL;
 export const DEFAULT_SETUP_BIND_TELEGRAM = true as const;
 
-export const DEFAULT_SETUP_MODEL_BY_PROVIDER = {
-  claude: "opus",
-  codex: "gpt-5.2",
-} as const;
-
 export const SETUP_MODEL_CHOICES_BY_PROVIDER = {
-  claude: ["opus", "sonnet", "haiku"],
-  codex: ["gpt-5.2", "gpt-5.2-codex"],
+  claude: ["haiku", "sonnet", "opus"],
+  codex: ["gpt-5.2", "gpt-5.2-codex", "gpt-5.3-codex"],
 } as const;
 
 export function getDefaultAgentDescription(agentName: string): string {


### PR DESCRIPTION
## Summary
- require explicit provider selection in interactive setup (no implicit default)
- require `--provider` on `hiboss agent register` (CLI + RPC typing/validation)
- change setup agent defaults to safer baseline (`auto-level=medium`, `permission-level=standard`)
- default setup model/reasoning to provider defaults (`null`)
- keep provider-switch behavior: clear model/reasoning to `null` when not explicitly passed
- add `boss` as setup permission-level option and support it in config-file setup
- update CLI/spec/guide docs and examples to match behavior

## Validation
- `npm run build`
- `npm run examples:cli`
