### PR TITLE
fix: resolve post-v2026.2.5 review follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ This project uses date-based npm versions (see `AGENTS.md`).
 
 ## [Unreleased]
 
+### Fixed
+- `defaults:check` now validates `agents.reasoning_effort` as a nullable column (no SQL default), matching runtime behavior where omitted reasoning effort stores `NULL` (provider default).
+- Scheduler orphan-envelope cleanup now queues follow-up ticks when the per-tick cleanup cap is reached, preventing leftover due orphan envelopes from remaining pending indefinitely.
+
+### Docs
+- Updated configuration docs to reflect `agents.reasoning_effort` default as `NULL`.
+- Updated scheduler docs to describe orphan cleanup batching/cap and follow-up tick behavior.
+- Updated `Agent` interface docs to require `provider`.
+
 ## [2026.2.5-rev.1-rc.1] - 2026-02-05
 
 ### Added
@@ -17,4 +26,3 @@ This project uses date-based npm versions (see `AGENTS.md`).
 
 ### Notes
 - Existing stable release prior to adopting `CHANGELOG.md`.
-

--- a/docs/spec/components/scheduler.md
+++ b/docs/spec/components/scheduler.md
@@ -53,6 +53,7 @@ Each tick does:
    - `db.listAgentNamesWithDueEnvelopes()` returns agent names with due pending envelopes
    - The scheduler calls `executor.checkAndRun(agent, db)` (non-blocking)
    - If an envelope is addressed to a missing/deleted agent (`to = agent:<name>` with no corresponding agent record), the scheduler marks those due pending envelopes `done` (terminal) and records `last-delivery-error-*` to prevent infinite pending loops
+   - Orphan cleanup is batched (`100`) and capped per tick (`2000`); if the cap is hit and more due orphan envelopes remain, the scheduler queues an immediate follow-up tick to continue cleanup
 
 The scheduler then computes the next wake time.
 

--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -139,7 +139,7 @@ Per-agent settings:
 | `workspace` | TEXT | `NULL` | Passed to the provider runtime as the session working directory |
 | `provider` | TEXT | `'claude'` | `"claude"` or `"codex"` |
 | `model` | TEXT | `NULL` | Optional model name. `NULL` means “use the provider default model”. |
-| `reasoning_effort` | TEXT | `'medium'` | `"none"`, `"low"`, `"medium"`, `"high"`, or `"xhigh"`. `NULL` means “use the provider default reasoning effort”. |
+| `reasoning_effort` | TEXT | `NULL` | `"none"`, `"low"`, `"medium"`, `"high"`, or `"xhigh"`. `NULL` means “use the provider default reasoning effort”. |
 | `auto_level` | TEXT | `'medium'` | `"medium"` or `"high"`. Note: unified-agent-sdk also supports `"low"`, but Hi-Boss disallows it because it can prevent the agent from running `hiboss` commands. |
 | `permission_level` | TEXT | `'standard'` | `"restricted"`, `"standard"`, `"privileged"`, or `"boss"` |
 | `session_policy` | TEXT | `NULL` | JSON blob for SessionPolicyConfig |

--- a/docs/spec/definitions.md
+++ b/docs/spec/definitions.md
@@ -337,7 +337,7 @@ export interface Agent {
   token: string;
   description?: string;
   workspace?: string;
-  provider?: "claude" | "codex";
+  provider: "claude" | "codex";
   model?: string;
   reasoningEffort?: "none" | "low" | "medium" | "high" | "xhigh";
   autoLevel?: "medium" | "high";

--- a/scripts/check-defaults.ts
+++ b/scripts/check-defaults.ts
@@ -3,7 +3,6 @@ import {
   DEFAULT_AGENT_AUTO_LEVEL,
   DEFAULT_AGENT_PERMISSION_LEVEL,
   DEFAULT_AGENT_PROVIDER,
-  DEFAULT_AGENT_REASONING_EFFORT,
   DEFAULT_AGENT_RUN_STATUS,
   DEFAULT_ENVELOPE_STATUS,
 } from "../src/shared/defaults.js";
@@ -28,7 +27,7 @@ function main(): void {
   );
   assertIncludes(
     normalized,
-    `reasoning_effort TEXT DEFAULT '${DEFAULT_AGENT_REASONING_EFFORT}'`,
+    "reasoning_effort TEXT",
     "agents.reasoning_effort"
   );
   assertIncludes(
@@ -62,4 +61,3 @@ try {
   console.error(message);
   process.exit(1);
 }
-


### PR DESCRIPTION
## Summary\n\nThis PR implements the high-priority follow-ups identified in the post-`v2026.2.5` review:\n\n- fixes defaults contract drift between schema/runtime and `defaults:check`\n- prevents orphan-envelope cleanup from stalling when per-tick cap is reached\n- aligns spec docs with current runtime behavior\n- documents these follow-up fixes in `CHANGELOG.md` under `Unreleased`\n\n## Changes\n\n- `scripts/check-defaults.ts`\n  - stop requiring a SQL default for `agents.reasoning_effort`; validate the nullable column shape instead\n- `src/daemon/scheduler/envelope-scheduler.ts`\n  - after capped orphan cleanup, probe for remaining due orphan envelopes\n  - queue an immediate follow-up tick when more work remains\n  - include `more-pending` in cleanup log fields\n- `docs/spec/configuration.md`\n  - update `agents.reasoning_effort` default to `NULL`\n- `docs/spec/definitions.md`\n  - update documented `Agent` interface to require `provider`\n- `docs/spec/components/scheduler.md`\n  - document orphan cleanup batching/cap and follow-up tick behavior\n- `CHANGELOG.md`\n  - add unreleased entries for these fixes/docs updates\n\n## Validation\n\n- `npm run typecheck`\n- `npm run build`\n- `npm run defaults:check`\n- `npm run prompts:check`\n- `npx tsx --test src/adapters/telegram/outgoing.test.ts`\n