### PR TITLE
chore: sync unified-agent-sdk and require isolated real provider verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,18 @@ Useful checks (run when relevant):
 - `npm run verify:token-usage:real` (talks to a real provider; use intentionally)
 - `npm run inventory:magic` (updates `docs/spec/generated/magic-inventory.md`; do not hand-edit that file)
 
+Real provider verification policy (required for provider/dependency/runtime changes):
+- If code or dependencies affect agent runtime/provider behavior (including `@unified-agent-sdk/*` changes), verify with **real** Codex + Claude requests before merging.
+- By default, use the official provider homes: `~/.codex` and `~/.claude`.
+  - Do not pass `--codex-home` / `--claude-home` unless explicitly testing overrides.
+- Keep tests isolated from normal operator state:
+  - Use a dedicated temporary Hi-Boss directory: `export HIBOSS_DIR="$(mktemp -d /tmp/hiboss-verify-XXXX)"`
+  - Never run destructive reset commands against default `~/hiboss` during verification.
+- Minimum real-request verification checklist:
+  - `npm run verify:token-usage:real -- --provider both --session-mode fresh --turns 1`
+  - `npm run verify:token-usage:real -- --provider both --session-mode continuous --turns 2`
+  - Run one isolated daemon-level smoke flow (setup/start/register/send/list) in the temp `HIBOSS_DIR` and confirm both provider-backed agents complete at least one run.
+
 ## Versioning & publishing
 
 Terminology:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,12 @@
     "": {
       "name": "hiboss",
       "version": "2026.2.5-rev.1-rc.1",
+      "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
         "@lancedb/lancedb": "^0.23.0",
         "@types/proper-lockfile": "^4.1.4",
-        "@unified-agent-sdk/runtime": "^0.6.1",
+        "@unified-agent-sdk/runtime": "^0.6.2",
         "apache-arrow": "^18.1.0",
         "better-sqlite3": "^11.7.0",
         "commander": "^13.0.0",
@@ -31,12 +32,15 @@
         "@types/nunjucks": "^3.2.6",
         "tsx": "^4.19.2",
         "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.29",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.29.tgz",
-      "integrity": "sha512-b+655n4ZqqAiMQEL3P44e9UurkI7WWanWTQQQTEcKngL5YCjjXExEPEJRxrmqp8mQXs0kLErZhObx0ZuwibOhA==",
+      "version": "0.2.33",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.33.tgz",
+      "integrity": "sha512-Ox7Vb8hXgnZyq9f5OtZJCmJ4Ag2LtAXmCJ3e/RD4pohYVUZelRaPeMeUHuS5bAykbHYdu4r9hloSaTCSsNiiVw==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
@@ -1840,9 +1844,9 @@
       }
     },
     "node_modules/@openai/codex-sdk": {
-      "version": "0.93.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.93.0.tgz",
-      "integrity": "sha512-9eHMhbXVIylI+lgh+Kput2DEakbYmJBTGHMXgzWwV58/NRrYVCKiAbWS462fHnlRxrJcF7Lmofa0V7uOZp7w7Q==",
+      "version": "0.98.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.98.0.tgz",
+      "integrity": "sha512-TbPgrBpuSNMJyOXys0HNsh6UoP5VIHu1fVh2KDdACi5XyB0vuPtzBZC+qOsxHz7WXEQPFlomPLyxS6JnE5Okmg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -2085,40 +2089,40 @@
       "license": "MIT"
     },
     "node_modules/@unified-agent-sdk/provider-claude": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@unified-agent-sdk/provider-claude/-/provider-claude-0.6.1.tgz",
-      "integrity": "sha512-MEMnxKVfHFprfspni8Q+OT+8jQ/aNZoLBF8VeM1Yv0POFHMf4naWRkNZu7KEDrJSvN/lZ7mNXVwUwciBTmcyzw==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@unified-agent-sdk/provider-claude/-/provider-claude-0.6.2.tgz",
+      "integrity": "sha512-cvg3Hlvn3lyH8LatL/Yt+1GH2w5UxwTBIZ8+9inIIMXqfz+YoydwBD//g9xKeV39HwyAp4npCFGQkxKF+wTqyg==",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.17",
-        "@unified-agent-sdk/runtime-core": "^0.6.1"
+        "@anthropic-ai/claude-agent-sdk": "^0.2.33",
+        "@unified-agent-sdk/runtime-core": "^0.6.2"
       }
     },
     "node_modules/@unified-agent-sdk/provider-codex": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@unified-agent-sdk/provider-codex/-/provider-codex-0.6.1.tgz",
-      "integrity": "sha512-FUzpDQFpVFdA1py/w4cGQj05jzkiQwE6akiKNIhWWGLoKw15B1YezQTtgpkW7b3O8/jHAoSrRIPj+kH/lqYUtA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@unified-agent-sdk/provider-codex/-/provider-codex-0.6.2.tgz",
+      "integrity": "sha512-y8g9BOLlw/ZFDhRXU9g0TOGiQuZM9PqlDS6nH5GbuBk5eaKTuEfZL/ad0PdT8EhLuRoOafo8xPrr8KLiWy+hOw==",
       "license": "MIT",
       "dependencies": {
-        "@openai/codex-sdk": "*",
-        "@unified-agent-sdk/runtime-core": "^0.6.1"
+        "@openai/codex-sdk": "^0.98.0",
+        "@unified-agent-sdk/runtime-core": "^0.6.2"
       }
     },
     "node_modules/@unified-agent-sdk/runtime": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@unified-agent-sdk/runtime/-/runtime-0.6.1.tgz",
-      "integrity": "sha512-MeXYG1ipU8Fhm9LO2QVouoC+eUzwoLRjSdbDTYGKURLA0ISOu6JRMMpZvNwF0Uabf9pqbx462Ml2XOmPgfMpXQ==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@unified-agent-sdk/runtime/-/runtime-0.6.2.tgz",
+      "integrity": "sha512-ZivL6wZTcQy/rJ9DjYuwJzcL2SFR4wpn2yHDZialbRcutVX232+eynXXAoAFviOtmO5EaMtjJjySFixebJbaZw==",
       "license": "MIT",
       "dependencies": {
-        "@unified-agent-sdk/provider-claude": "^0.6.1",
-        "@unified-agent-sdk/provider-codex": "^0.6.1",
-        "@unified-agent-sdk/runtime-core": "^0.6.1"
+        "@unified-agent-sdk/provider-claude": "^0.6.2",
+        "@unified-agent-sdk/provider-codex": "^0.6.2",
+        "@unified-agent-sdk/runtime-core": "^0.6.2"
       }
     },
     "node_modules/@unified-agent-sdk/runtime-core": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@unified-agent-sdk/runtime-core/-/runtime-core-0.6.1.tgz",
-      "integrity": "sha512-y7Hb3CAcrwRZPlKq1hDzbxnz7MLO3oiikzOlqyMRkFLvqHCYCXMVsJ+4fck/uYu6xDT/sSSgBTne/gfQ0Vtq0g==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@unified-agent-sdk/runtime-core/-/runtime-core-0.6.2.tgz",
+      "integrity": "sha512-mBIrDXN42tzAtea5z/bbJEUK+XMJOALRDALEuhxq69c0w1wXoQR7D3ONzLHArYiNmFRoUFaRCW3f3kY4VkdU1A==",
       "license": "MIT"
     },
     "node_modules/a-sync-waterfall": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@inquirer/prompts": "^7.0.0",
     "@lancedb/lancedb": "^0.23.0",
     "@types/proper-lockfile": "^4.1.4",
-    "@unified-agent-sdk/runtime": "^0.6.1",
+    "@unified-agent-sdk/runtime": "^0.6.2",
     "apache-arrow": "^18.1.0",
     "better-sqlite3": "^11.7.0",
     "commander": "^13.0.0",


### PR DESCRIPTION
## Summary
- upgrade `@unified-agent-sdk/runtime` to latest (`0.6.2`)
- update lockfile to the resolved latest runtime/runtime-core packages
- update `AGENTS.md` with a required real-provider verification policy for provider/runtime/dependency changes

## AGENTS.md updates
- require real Codex + Claude request verification when provider/runtime/dependency behavior changes
- default to official provider homes: `~/.codex`, `~/.claude`
- require isolated test environments via temp `HIBOSS_DIR` (no destructive operations against default `~/hiboss`)
- add a minimum verification checklist:
  - `verify:token-usage:real` in fresh + continuous modes
  - isolated daemon-level smoke flow with both providers completing runs

## Validation
- `npm run typecheck`
- real provider checks previously executed in this branch context:
  - `npm run verify:token-usage:real -- --provider both --session-mode fresh --turns 2 --filler-words 64`
  - `npm run verify:token-usage:real -- --provider both --session-mode continuous --turns 2 --filler-words 64`
- isolated daemon-level real-provider smoke executed with temporary `HIBOSS_DIR` and both codex/claude agents completing runs

