### PR TITLE
docs(readme): document abort command

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Remove an agent:
 hiboss agent delete --token <boss-token> --name nex
 ```
 
-List / status / abort:
+List / status:
 
 ```bash
 hiboss agent list --token <boss-token>


### PR DESCRIPTION
## Summary
- add Telegram `/abort` to the boss-only command list in `README.md`
- add `hiboss agent abort` example in the Agent section command snippets

## Validation
- npm run build
