### PR TITLE
docs(skill): add prerequisites to agent-browser SKILL.md

### DIFF
--- a/skills/.system/agent-browser/SKILL.md
+++ b/skills/.system/agent-browser/SKILL.md
@@ -6,6 +6,33 @@ allowed-tools: Bash(agent-browser:*)
 
 # Browser Automation with agent-browser
 
+## Prerequisites
+
+This skill requires `agent-browser` version **0.9.1**.
+
+**Check if installed:**
+
+```bash
+agent-browser --version
+```
+
+If the command is not found or the version does not match 0.9.1, install it:
+
+```bash
+# If previously installed via Homebrew, remove it first to avoid PATH conflicts:
+# brew uninstall agent-browser
+
+npm install -g agent-browser@0.9.1
+```
+
+After installing, download the bundled Chromium browser:
+
+```bash
+agent-browser install
+# On Linux, include system dependencies:
+agent-browser install --with-deps
+```
+
 ## Core Workflow
 
 Every browser automation follows this pattern:


### PR DESCRIPTION
## Summary

- Add a `## Prerequisites` section to the agent-browser skill telling agents which version is required (0.9.1), how to install via npm with an exact version pin, and the post-install Chromium download step
- Include a note to uninstall any prior Homebrew install to avoid PATH conflicts
- No change to `builtin-sources.json` since upstream skill files haven't changed

## Test plan

- [x] `wc -l skills/.system/agent-browser/SKILL.md` confirms under 500 lines (245)
- [x] `npm run build` passes
- [x] Markdown renders correctly (headers, code blocks, bold)
- [x] Skill sync picks up the content change via `hashEntry()` on next session creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)