### PR TITLE
chore(setup): change default leader name to kai

### DIFF
--- a/docs/spec/cli/setup.md
+++ b/docs/spec/cli/setup.md
@@ -34,7 +34,7 @@ Interactive defaults:
 - `speaker.permission-level`: `standard`
 - `speaker.model`: `null` (provider default)
 - `speaker.reasoning-effort`: `null` (provider default)
-- `leader.name`: `leader`
+- `leader.name`: `kai`
 - `leader.workspace`: speaker workspace
 - `leader.permission-level`: speaker value
 - `leader.model`: `null` (provider default)
@@ -163,7 +163,7 @@ Invariants:
       ]
     },
     {
-      "name": "leader",
+      "name": "kai",
       "role": "leader",
       "provider": "claude",
       "description": "A reliable and collaborative professional...",

--- a/src/cli/commands/setup/declarative.ts
+++ b/src/cli/commands/setup/declarative.ts
@@ -73,10 +73,10 @@ function buildDefaultDeclarativeConfig(): SetupDeclarativeConfig {
         ],
       },
       {
-        name: "leader",
+        name: "kai",
         role: "leader",
         provider: "claude",
-        description: getDefaultAgentDescription("leader"),
+        description: getDefaultAgentDescription("kai"),
         workspace,
         model: null,
         reasoningEffort: null,

--- a/src/cli/commands/setup/interactive.ts
+++ b/src/cli/commands/setup/interactive.ts
@@ -164,7 +164,7 @@ export async function runInteractiveSetup(): Promise<void> {
   const leaderAgentName = (
     await input({
       message: "Leader agent name (slug):",
-      default: "leader",
+      default: "kai",
       validate: (value) => {
         const name = value.trim();
         if (!isValidAgentName(name)) return AGENT_NAME_ERROR_MESSAGE;


### PR DESCRIPTION
## Summary
- change interactive setup leader name default from `leader` to `kai`
- change declarative default exported setup config leader name from `leader` to `kai`
- update setup CLI spec defaults/example to match behavior

## Validation
- npm run build
- npm link
