### PR TITLE
feat(cli): add agent register dry-run, cron explain, and envelope time filters

### DIFF
--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -33,6 +33,7 @@ Default permission levels below come from the built-in permission policy (`DEFAU
 | `hiboss envelope list` | List envelopes | Yes (agent token) | restricted |
 | `hiboss envelope thread` | Show envelope thread | Yes (agent token) | restricted |
 | `hiboss cron create` | Create a cron schedule | Yes (agent token) | restricted |
+| `hiboss cron explain` | Validate cron + preview upcoming run times | Yes when `--timezone` omitted; otherwise no | n/a |
 | `hiboss cron list` | List cron schedules | Yes (agent token) | restricted |
 | `hiboss cron enable` | Enable a cron schedule | Yes (agent token) | restricted |
 | `hiboss cron disable` | Disable a cron schedule | Yes (agent token) | restricted |

--- a/docs/spec/cli/agents.md
+++ b/docs/spec/cli/agents.md
@@ -24,6 +24,7 @@ Flags:
   - `--session-daily-reset-at HH:MM`
   - `--session-idle-timeout <duration>` (units: `d/h/m/s`)
   - `--session-max-context-length <n>`
+- `--dry-run` (optional; validate only, no mutation)
 
 Behavior when flags are omitted:
 Required flags (validation error):
@@ -52,9 +53,11 @@ Output (parseable):
 - `description:` (always; generated default when omitted; may be empty string)
 - `workspace:` (`(none)` when unset)
 - `token:` (printed once)
+- `dry-run: true` (only when `--dry-run` is set)
 
 Note:
 - In `agent register` output, `workspace: (none)` means no explicit override is stored. Effective runtime workspace falls back to the user's home directory.
+- In dry-run mode, `token:` is rendered as `(dry-run)` and no agent/token is persisted.
 
 ## `hiboss agent set`
 

--- a/docs/spec/cli/cron.md
+++ b/docs/spec/cli/cron.md
@@ -29,6 +29,31 @@ cron-id: <cron-id>  # short id
 Default permission:
 - `restricted`
 
+Errors:
+- Invalid cron expressions return a normalized message:
+  - `error: Invalid cron: <expr> (...)`
+  - The message includes accepted formats (`5-field/6-field` or presets like `@daily`).
+
+## `hiboss cron explain`
+
+Validates a cron expression and prints upcoming run times without creating a schedule.
+
+Flags:
+- `--cron <expr>` (required; 5-field or 6-field with optional seconds; `@daily` etc supported)
+- `--timezone <iana>` (optional; when omitted, resolves boss timezone from daemon)
+- `--count <n>` (optional; default `5`, max `20`)
+- `--token <token>` (optional; defaults to `HIBOSS_TOKEN`; only needed when `--timezone` is omitted)
+
+Output (parseable):
+- `cron:`
+- `timezone:`
+- `count:`
+- `evaluated-at:` (selected timezone offset)
+- `next-run-1:` ... `next-run-N:` (selected timezone offset)
+
+Default permission:
+- n/a (local evaluation); resolving implicit boss timezone uses `daemon.time` and therefore requires a token
+
 ## `hiboss cron list`
 
 Lists cron schedules for the current agent.

--- a/docs/spec/cli/envelopes.md
+++ b/docs/spec/cli/envelopes.md
@@ -81,7 +81,12 @@ Flags:
   - `--to <address>`: list envelopes sent **by this agent** to `<address>`
   - `--from <address>`: list envelopes sent **to this agent** from `<address>`
 - `--status <pending|done>` (required)
+- `--created-after <time>` (optional; filter `created-at >= time`; ISO 8601 or relative `+2h`, `+30m`, `+1Y2M`, `-15m`; units: `Y/M/D/h/m/s`)
+- `--created-before <time>` (optional; filter `created-at <= time`; same format as `--created-after`)
 - `-n, --limit <n>` (default: `10`, max: `50`)
+
+Validation:
+- If both date filters are present, `created-after` must be less than or equal to `created-before`.
 
 Default permission:
 - `restricted`

--- a/docs/spec/definitions.md
+++ b/docs/spec/definitions.md
@@ -123,6 +123,13 @@ Notes:
 `hiboss cron create` prints:
 - `cron-id: <cron-id>` (short id; derived from the internal cron schedule UUID)
 
+`hiboss cron explain` prints:
+- `cron:`
+- `timezone:`
+- `count:`
+- `evaluated-at:`
+- `next-run-1:` ... `next-run-N:`
+
 `hiboss cron enable|disable|delete` print:
 - `success: true|false`
 - `cron-id: <cron-id>` (short id; derived from the internal cron schedule UUID)
@@ -197,7 +204,9 @@ Clearing nullable overrides:
   - `description:` (always; generated default when omitted; may be empty string)
   - `workspace:` (`(none)` when unset)
   - `token:` (printed once; there is no “show token” command)
+  - `dry-run: true` (only when `--dry-run` is set)
 - In `hiboss agent register` output, `workspace: (none)` means no explicit override is stored; effective runtime workspace falls back to the user's home directory.
+- In `hiboss agent register --dry-run`, `token:` is rendered as `(dry-run)` and no agent/token is persisted.
 - First-time interactive `hiboss setup` prints setup summary keys including:
   - `daemon-timezone: <iana>`
   - `boss-timezone: <iana>`

--- a/prompts/system/sections/hiboss/cli-tools.md
+++ b/prompts/system/sections/hiboss/cli-tools.md
@@ -63,8 +63,10 @@ EOF
 **Listing messages (when needed):**
 - The daemon already gathers pending envelopes into your turn input; you usually do **not** need `hiboss envelope list`.
 - Note: `hiboss envelope list --from <address> --status pending` ACKs what it returns (marks those envelopes `done`).
+- For targeted history windows, use `--created-after <time>` / `--created-before <time>` on `hiboss envelope list`.
 
 For details/examples, use:
 - `hiboss envelope send --help`
 - `hiboss envelope list --help`
 - `hiboss cron --help`
+- `hiboss cron explain --help`

--- a/src/cli/cli-agent.ts
+++ b/src/cli/cli-agent.ts
@@ -49,6 +49,7 @@ export function registerAgentCommands(program: Command): void {
     .option("--metadata-file <path>", "Path to agent metadata JSON file")
     .option("--bind-adapter-type <type>", "Bind adapter type at creation (e.g., telegram)")
     .option("--bind-adapter-token <token>", "Bind adapter token at creation (e.g., bot token)")
+    .option("--dry-run", "Validate registration without creating the agent")
     .action((options) => {
       registerAgent({
         token: options.token,
@@ -67,6 +68,7 @@ export function registerAgentCommands(program: Command): void {
         metadataFile: options.metadataFile,
         bindAdapterType: options.bindAdapterType,
         bindAdapterToken: options.bindAdapterToken,
+        dryRun: Boolean(options.dryRun),
       });
     });
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -10,6 +10,7 @@ import {
   listEnvelopes,
   threadEnvelope,
   createCron,
+  explainCron,
   listCrons,
   enableCron,
   disableCron,
@@ -184,6 +185,14 @@ envelope
     "--status <status>",
     "pending or done (note: --from + pending ACKs what is returned; marks done)"
   )
+  .option(
+    "--created-after <time>",
+    "Filter by created-at >= time (ISO 8601 or relative: +2h, +30m, +1Y2M, -15m; units: Y/M/D/h/m/s)"
+  )
+  .option(
+    "--created-before <time>",
+    "Filter by created-at <= time (ISO 8601 or relative: +2h, +30m, +1Y2M, -15m; units: Y/M/D/h/m/s)"
+  )
   .option("-n, --limit <n>", "Maximum number of results (default 10, max 50)", parseInt, 10)
   .addHelpText(
     "after",
@@ -195,6 +204,8 @@ envelope
       to: options.to,
       from: options.from,
       status: options.status as "pending" | "done",
+      createdAfter: options.createdAfter,
+      createdBefore: options.createdBefore,
       limit: options.limit,
     });
   });
@@ -236,6 +247,25 @@ cron
       textFile: options.textFile,
       attachment: options.attachment,
       parseMode: options.parseMode,
+    });
+  });
+
+cron
+  .command("explain")
+  .description("Explain a cron expression by showing upcoming run times")
+  .requiredOption(
+    "--cron <expr>",
+    "Cron expression (5-field or 6-field with seconds; supports @daily, @hourly, ...)"
+  )
+  .option("--timezone <iana>", "IANA timezone (defaults to boss timezone)")
+  .option("--count <n>", "Number of upcoming runs to show (default 5, max 20)", parseInt, 5)
+  .option("--token <token>", "Token (defaults to HIBOSS_TOKEN; only needed when --timezone is omitted)")
+  .action((options) => {
+    explainCron({
+      cron: options.cron,
+      timezone: options.timezone,
+      count: options.count,
+      token: options.token,
     });
   });
 

--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -15,8 +15,9 @@ export { setAgentSessionPolicy } from "./agent-session-policy.js";
 export type { SetAgentSessionPolicyOptions } from "./agent-session-policy.js";
 
 interface RegisterAgentResult {
+  dryRun?: boolean;
   agent: Omit<Agent, "token">;
-  token: string;
+  token?: string;
 }
 
 interface AgentWithBindings extends Omit<Agent, "token"> {
@@ -57,6 +58,7 @@ export interface RegisterAgentOptions {
   metadataFile?: string;
   bindAdapterType?: string;
   bindAdapterToken?: string;
+  dryRun?: boolean;
 }
 
 export interface DeleteAgentOptions {
@@ -131,13 +133,24 @@ export async function registerAgent(options: RegisterAgentOptions): Promise<void
       sessionMaxContextLength: options.sessionMaxContextLength,
       bindAdapterType: options.bindAdapterType,
       bindAdapterToken: options.bindAdapterToken,
+      dryRun: Boolean(options.dryRun),
     });
 
+    if (result.dryRun) {
+      console.log("dry-run: true");
+    }
     console.log(`name: ${result.agent.name}`);
     console.log(`role: ${result.agent.role ?? "(missing)"}`);
     console.log(`description: ${result.agent.description ?? "(none)"}`);
     console.log(`workspace: ${result.agent.workspace ?? "(none)"}`);
-    console.log(`token: ${result.token}`);
+    if (result.dryRun) {
+      console.log("token: (dry-run)");
+    } else {
+      if (typeof result.token !== "string" || !result.token.trim()) {
+        throw new Error("Registration succeeded but token was not returned");
+      }
+      console.log(`token: ${result.token}`);
+    }
   } catch (err) {
     console.error("error:", (err as Error).message);
     process.exit(1);

--- a/src/cli/commands/envelope.ts
+++ b/src/cli/commands/envelope.ts
@@ -40,6 +40,8 @@ export interface ListEnvelopesOptions {
   to?: string;
   from?: string;
   status: "pending" | "done";
+  createdAfter?: string;
+  createdBefore?: string;
   limit?: number;
 }
 
@@ -205,6 +207,8 @@ export async function listEnvelopes(options: ListEnvelopesOptions): Promise<void
       to: options.to,
       from: options.from,
       status: options.status,
+      createdAfter: options.createdAfter,
+      createdBefore: options.createdBefore,
       limit: options.limit,
     });
 

--- a/src/daemon/db/database.ts
+++ b/src/daemon/db/database.ts
@@ -840,11 +840,23 @@ export class HiBossDatabase {
     status: EnvelopeStatus;
     limit: number;
     dueOnly?: boolean;
+    createdAfter?: number;
+    createdBefore?: number;
   }): Envelope[] {
-    const { from, to, status, limit, dueOnly } = options;
+    const { from, to, status, limit, dueOnly, createdAfter, createdBefore } = options;
 
     let sql = `SELECT * FROM envelopes WHERE "from" = ? AND "to" = ? AND status = ?`;
     const params: (string | number)[] = [from, to, status];
+
+    if (typeof createdAfter === "number") {
+      sql += " AND created_at >= ?";
+      params.push(createdAfter);
+    }
+
+    if (typeof createdBefore === "number") {
+      sql += " AND created_at <= ?";
+      params.push(createdBefore);
+    }
 
     if (dueOnly) {
       const nowMs = Date.now();

--- a/src/daemon/ipc/types.ts
+++ b/src/daemon/ipc/types.ts
@@ -72,6 +72,8 @@ export interface EnvelopeListParams {
   from?: string;
   status: "pending" | "done";
   limit?: number;
+  createdAfter?: string;
+  createdBefore?: string;
 }
 
 export interface EnvelopeThreadParams {
@@ -136,6 +138,7 @@ export interface AgentRegisterParams {
   sessionMaxContextLength?: number;
   bindAdapterType?: string;
   bindAdapterToken?: string;
+  dryRun?: boolean;
 }
 
 export interface AgentDeleteParams {

--- a/src/shared/cron.ts
+++ b/src/shared/cron.ts
@@ -1,10 +1,96 @@
 import { CronExpressionParser } from "cron-parser";
 
+function formatCronParseError(params: {
+  cron: string;
+  timezone: string;
+  error: unknown;
+}): string {
+  const raw =
+    params.error instanceof Error ? params.error.message.trim() : String(params.error).trim();
+  const details = raw ? ` (${raw})` : "";
+  return (
+    `Invalid cron: ${params.cron}${details}. ` +
+    `Expected 5-field/6-field cron (optional seconds) or presets like @daily; timezone=${params.timezone}.`
+  );
+}
+
+function parseCronInterval(params: {
+  cron: string;
+  afterDate: Date;
+  timezone: string;
+}): ReturnType<typeof CronExpressionParser.parse> {
+  try {
+    return CronExpressionParser.parse(params.cron, {
+      currentDate: params.afterDate,
+      tz: params.timezone,
+    });
+  } catch (err) {
+    throw new Error(
+      formatCronParseError({
+        cron: params.cron,
+        timezone: params.timezone,
+        error: err,
+      })
+    );
+  }
+}
+
+function normalizeRunCount(count: number | undefined): number {
+  if (count === undefined) return 1;
+  if (!Number.isFinite(count)) {
+    throw new Error("Invalid count (must be a finite number)");
+  }
+  const n = Math.trunc(count);
+  if (n <= 0) {
+    throw new Error("Invalid count (must be >= 1)");
+  }
+  if (n > 50) {
+    throw new Error("Invalid count (max 50)");
+  }
+  return n;
+}
+
 export function normalizeTimeZoneInput(timezone?: string): string | undefined {
   if (!timezone) return undefined;
   const trimmed = timezone.trim();
   if (!trimmed) return undefined;
   return trimmed;
+}
+
+export function computeNextCronUnixMsSeries(params: {
+  cron: string;
+  timezone?: string; // explicit schedule timezone (IANA); missing means "inherit bossTimezone"
+  bossTimezone: string;
+  afterDate?: Date;
+  count?: number;
+}): number[] {
+  const after = params.afterDate ?? new Date();
+  const afterMs = after.getTime();
+  const tz = normalizeTimeZoneInput(params.timezone) ?? params.bossTimezone;
+  const wanted = normalizeRunCount(params.count);
+  const interval = parseCronInterval({
+    cron: params.cron,
+    afterDate: after,
+    timezone: tz,
+  });
+
+  const runs: number[] = [];
+  try {
+    while (runs.length < wanted) {
+      const next = interval.next().toDate();
+      const nextMs = next.getTime();
+      // Ensure strict "next after now" semantics (skip misfires / no immediate delivery).
+      if (nextMs <= afterMs) continue;
+      runs.push(nextMs);
+    }
+  } catch (err) {
+    const raw =
+      err instanceof Error ? err.message.trim() : String(err).trim();
+    const details = raw ? ` (${raw})` : "";
+    throw new Error(`Failed to compute next run times${details}`);
+  }
+
+  return runs;
 }
 
 export function computeNextCronUnixMs(params: {
@@ -13,20 +99,8 @@ export function computeNextCronUnixMs(params: {
   bossTimezone: string;
   afterDate?: Date;
 }): number {
-  const after = params.afterDate ?? new Date();
-  const afterMs = after.getTime();
-  const tz = normalizeTimeZoneInput(params.timezone) ?? params.bossTimezone;
-
-  const interval = CronExpressionParser.parse(params.cron, {
-    currentDate: after,
-    tz,
-  });
-
-  // Ensure strict "next after now" semantics (skip misfires / no immediate delivery).
-  let next = interval.next().toDate();
-  while (next.getTime() <= afterMs) {
-    next = interval.next().toDate();
-  }
-
-  return next.getTime();
+  return computeNextCronUnixMsSeries({
+    ...params,
+    count: 1,
+  })[0];
 }


### PR DESCRIPTION
## Summary
- add `hiboss agent register --dry-run` validation path with parseable dry-run output
- add `hiboss cron explain` to preview next run times and normalize cron parse errors
- add `hiboss envelope list --created-after/--created-before` filters with range validation
- update CLI/spec definitions and system CLI prompt hints for new commands/flags

## Validation
- npm run typecheck
- npm run build
- npm run prompts:check
- npm run examples:prompts
- npm run examples:cli
- real-provider smoke: npm run verify:token-usage:real -- --provider both --session-mode fresh --turns 1
- isolated real-agent e2e checks (non-setup CLI flows): envelope/cron/admin command groups
