### PR TITLE
docs(readme): fix sponsor logo rendering path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Highlights:
 
 ## Sponsor
 
-[![YesCode logo](docs/assets/sponsors/yescode-logo.png)](https://co.yes.vg/register?ref=KKYC1Z0)
+[![YesCode logo](/evilpsycho42/hi-boss/blob/main/docs/assets/sponsors/yescode-logo.png?raw=1)](https://co.yes.vg/register?ref=KKYC1Z0)
 
 YesCode is a reliable Claude Code/Codex relay provider with stable service quality and reasonable pricing.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,7 +12,7 @@
 
 ## 赞助
 
-[![YesCode logo](docs/assets/sponsors/yescode-logo.png)](https://co.yes.vg/register?ref=KKYC1Z0)
+[![YesCode logo](/evilpsycho42/hi-boss/blob/main/docs/assets/sponsors/yescode-logo.png?raw=1)](https://co.yes.vg/register?ref=KKYC1Z0)
 
 YesCode 是稳定可靠、价格合理的 Claude Code/Codex 中转服务提供商。
 


### PR DESCRIPTION
## Summary
- fix sponsor logo URL in README.md and README.zh-CN.md
- use a repo-root absolute GitHub blob raw path to avoid homepage relative path resolution issues
- keep sponsor referral link unchanged

## Why
On the repository homepage, the previous docs/assets/sponsors path resolved incorrectly and produced a broken image.