### PR TITLE
docs(readme): fix sponsor logo image path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Highlights:
 
 ## Sponsor
 
-[![YesCode logo](/evilpsycho42/hi-boss/blob/main/docs/assets/sponsors/yescode-logo.png?raw=1)](https://co.yes.vg/register?ref=KKYC1Z0)
+[![YesCode logo](docs/assets/sponsors/yescode-logo.png)](https://co.yes.vg/register?ref=KKYC1Z0)
 
 YesCode is a reliable Claude Code/Codex relay provider with stable service quality and reasonable pricing.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,7 +12,7 @@
 
 ## 赞助
 
-[![YesCode logo](/evilpsycho42/hi-boss/blob/main/docs/assets/sponsors/yescode-logo.png?raw=1)](https://co.yes.vg/register?ref=KKYC1Z0)
+[![YesCode logo](docs/assets/sponsors/yescode-logo.png)](https://co.yes.vg/register?ref=KKYC1Z0)
 
 YesCode 是稳定可靠、价格合理的 Claude Code/Codex 中转服务提供商。
 


### PR DESCRIPTION
## Summary
- Fix broken sponsor (YesCode) logo image in both `README.md` and `README.zh-CN.md`
- Replace absolute path (`/evilpsycho42/hi-boss/blob/main/docs/assets/sponsors/yescode-logo.png?raw=1`) with relative path (`docs/assets/sponsors/yescode-logo.png`), which GitHub's markdown renderer resolves correctly within the repo context

## Test plan
- [ ] Verify the sponsor logo renders on the repo homepage (`README.md`)
- [ ] Verify the sponsor logo renders on the Chinese README (`README.zh-CN.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)