### PR TITLE
docs(readme): remove referral param from sponsor URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Highlights:
 
 ## Sponsor
 
-[![YesCode logo](docs/assets/sponsors/yescode-logo.png)](https://co.yes.vg/register?ref=KKYC1Z0)
+[![YesCode logo](docs/assets/sponsors/yescode-logo.png)](https://co.yes.vg)
 
 YesCode is a reliable Claude Code/Codex relay provider with stable service quality and reasonable pricing.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,7 +12,7 @@
 
 ## 赞助
 
-[![YesCode logo](docs/assets/sponsors/yescode-logo.png)](https://co.yes.vg/register?ref=KKYC1Z0)
+[![YesCode logo](docs/assets/sponsors/yescode-logo.png)](https://co.yes.vg)
 
 YesCode 是稳定可靠、价格合理的 Claude Code/Codex 中转服务提供商。
 


### PR DESCRIPTION
## Summary
- Remove the `?ref=KKYC1Z0` referral query parameter from the YesCode sponsor link in both `README.md` and `README.zh-CN.md`
- The referral URL is likely triggering GitHub's automated spam detection, which has flagged the account and caused the repo/profile to return 404 for unauthenticated visitors

## Test plan
- [ ] Verify the sponsor link in both READMEs points to `https://co.yes.vg`
- [ ] After merging, appeal the GitHub spam flag and confirm public access is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)